### PR TITLE
Publish to github pages for in-app access

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,27 +1,23 @@
-# Simple workflow for deploying static content to GitHub Pages
-name: Deploy static content to Pages
+name: Publish documentation for in-app access
 
 on:
-  # Runs on pushes targeting the default branch
   push:
     branches: ["main"]
 
-  # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
-# Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
+# Required permissions for deployment to GitHub Pages
 permissions:
   contents: read
   pages: write
   id-token: write
 
-# Allow one concurrent deployment
+# Disable concurrent deployments
 concurrency:
   group: "pages"
   cancel-in-progress: true
 
 jobs:
-  # Single deploy job since we're just deploying
   deploy:
     environment:
       name: github-pages
@@ -32,11 +28,12 @@ jobs:
         uses: actions/checkout@v3
       - name: Setup Pages
         uses: actions/configure-pages@v2
+      - name: Prepare public files
+        run: make public
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v1
         with:
-          # Upload entire repository
-          path: '.'
+          path: 'public'
       - name: Deploy to GitHub Pages
         id: deployment
         uses: actions/deploy-pages@v1

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,8 @@
+PUBLISH_DIRS=assets getting-started/data-warehouses
+
+public:
+	for dir in $(PUBLISH_DIRS); do \
+		echo "Publishing $$dir"; \
+		mkdir -p public/$$dir; \
+		cp $$dir/* public/$$dir; \
+	done


### PR DESCRIPTION
An alternative approach for https://github.com/datafold/datafold/pull/2241

Instead of routing all the requests through our backend, we could publish some resources to GitHub pages to be publicly available. Then we would be able to access in-app documentation from both SaaS and on-prem deployments.

I tested this approach in [this repository](https://github.com/datafold-test/documentation) and it looks like it may be the solution for us. For example, the following resource can be accessed by client as is: https://datafold-test.github.io/documentation/getting-started/data-warehouses/bigquery.md

The only question: 
Is it possible to have Github Pages enabled for a private repository https://github.com/datafold/documentation ?